### PR TITLE
Corrected inverted calloc parameters in buffer.c and vector.c

### DIFF
--- a/lib/src/buffer.c
+++ b/lib/src/buffer.c
@@ -6,8 +6,8 @@
 
 struct buffer* buffer_create()
 {
-    struct buffer* buf = calloc(sizeof(struct buffer), 1);
-    buf->data = calloc(BUFFER_REALLOC_AMOUNT, 1);
+    struct buffer* buf = calloc(1, sizeof(struct buffer));
+    buf->data = calloc(1, BUFFER_REALLOC_AMOUNT);
     buf->len = 0;
     buf->msize = BUFFER_REALLOC_AMOUNT;
     return buf;
@@ -15,7 +15,7 @@ struct buffer* buffer_create()
 
 struct buffer* buffer_wrap(void* data, size_t size)
 {
-    struct buffer* buf = calloc(sizeof(struct buffer), 1);
+    struct buffer* buf = calloc(1, sizeof(struct buffer));
     buf->data = data;
     buf->len = size;
     buf->msize = size;

--- a/lib/src/vector/vector.c
+++ b/lib/src/vector/vector.c
@@ -23,7 +23,7 @@ static void vector_assert_bounds_for_pop(struct vector *vector, int index)
 
 struct vector *vector_create_no_saves(size_t esize)
 {
-    struct vector *vector = calloc(sizeof(struct vector), 1);
+    struct vector *vector = calloc(1, sizeof(struct vector));
     vector->data = malloc(esize * VECTOR_ELEMENT_INCREMENT);
     vector->mindex = VECTOR_ELEMENT_INCREMENT;
     vector->rindex = 0;
@@ -45,9 +45,9 @@ size_t vector_element_size(struct vector *vector)
 
 struct vector *vector_clone(struct vector *vector)
 {
-    void *new_data_address = calloc(vector->esize, vector->count + VECTOR_ELEMENT_INCREMENT);
+    void *new_data_address = calloc(vector->count + VECTOR_ELEMENT_INCREMENT, vector->esize);
     memcpy(new_data_address, vector->data, vector_total_size(vector));
-    struct vector *new_vec = calloc(sizeof(struct vector), 1);
+    struct vector *new_vec = calloc(1, sizeof(struct vector));
     memcpy(new_vec, vector, sizeof(struct vector));
     new_vec->data = new_data_address;
 


### PR DESCRIPTION
In both helper files (buffer.c and vector.c), the calloc() function parameters were inverted.